### PR TITLE
Add toggle and spacing tweaks for trade preview footer

### DIFF
--- a/A1_DH-HQ copy 2/scripts/app.js
+++ b/A1_DH-HQ copy 2/scripts/app.js
@@ -893,10 +893,14 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
             tradeSimulator.style.display = 'block';
             tradeSimulator.innerHTML = `
+            <button id="tradeExpandButton">▲</button>
             <div class="trade-container glass-panel">
               <div class="trade-header">
                 <h3>Trade Preview</h3>
-                <button id="clearTradeButton">Clear</button>
+                <div class="flex gap-2">
+                  <button id="tradeCollapseButton">▼</button>
+                  <button id="clearTradeButton">Clear</button>
+                </div>
               </div>
               <div class="trade-body"></div>
               <div class="trade-footnote">• Non-Adjusted Values •</div>
@@ -963,6 +967,14 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             tradeBody.innerHTML = bodyHtml;
 
             document.getElementById('clearTradeButton').addEventListener('click', clearTrade);
+            document.getElementById('tradeCollapseButton').addEventListener('click', () => {
+                tradeSimulator.classList.add('collapsed');
+                mainContent.style.paddingBottom = '1rem';
+            });
+            document.getElementById('tradeExpandButton').addEventListener('click', () => {
+                tradeSimulator.classList.remove('collapsed');
+                mainContent.style.paddingBottom = `${tradeSimulator.offsetHeight + 40}px`;
+            });
             mainContent.style.paddingBottom = `${tradeSimulator.offsetHeight + 40}px`;
         }
 

--- a/A1_DH-HQ copy 2/styles/styles.css
+++ b/A1_DH-HQ copy 2/styles/styles.css
@@ -770,32 +770,32 @@
         .trade-container {
             display: flex;
             flex-direction: column;
-            gap: 0.5rem;
+            gap: 0.25rem;
         }
 
-        .trade-header { 
-            display: flex; 
-            justify-content: space-between; 
-            align-items: center; 
-            padding: 0 0.5rem; 
+        .trade-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0 0.5rem;
         }
-        .trade-header h3 { 
-            font-size: 1rem; 
-            font-weight: 500; 
+        .trade-header h3 {
+            font-size: 1rem;
+            font-weight: 500;
             color: #b0bcdb;
             text-shadow: 0 0 5px rgba(0,0,0,0.5);
         }
-        #clearTradeButton { 
-            background: var(--color-bg-light); 
-            color: var(--color-text-secondary); 
-            font-size: 0.8rem; 
-            padding: 4px 10px; 
+        .trade-header button {
+            background: var(--color-bg-light);
+            color: var(--color-text-secondary);
+            font-size: 0.8rem;
+            padding: 4px 10px;
             border-radius: 6px;
             border: 1px solid var(--color-panel-border);
             cursor: pointer;
             transition: all 0.2s;
         }
-        #clearTradeButton:hover {
+        .trade-header button:hover {
             color: var(--color-text-primary);
             border-color: var(--color-panel-border-glow);
         }
@@ -883,9 +883,27 @@
     font-size: 0.75em;
     color: #A0A6D0;
     font-weight: 300;
-    margin-top: 0.2rem;
+    margin-top: 0;
     padding-bottom: 0.1rem;
 }
+        #tradeExpandButton {
+            background: var(--color-bg-light);
+            color: var(--color-text-secondary);
+            font-size: 0.8rem;
+            padding: 4px 10px;
+            border-radius: 6px;
+            border: 1px solid var(--color-panel-border);
+            cursor: pointer;
+            transition: all 0.2s;
+            margin: 0 auto;
+            display: none;
+        }
+        #tradeSimulator.collapsed .trade-container {
+            display: none;
+        }
+        #tradeSimulator.collapsed #tradeExpandButton {
+            display: block;
+        }
 /* Only the Trade Preview popup glass */
 .trade-container.glass-panel {
   background-color: rgba(13,14,35,0.18);


### PR DESCRIPTION
## Summary
- Reduce spacing above trade preview footnote
- Add collapse/expand controls to trade preview popup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b44b2c4aac832e822c809290b46a1d