### PR TITLE
Add trade preview toggle and adjust footer spacing

### DIFF
--- a/A1_DH-HQ copy 2/scripts/app.js
+++ b/A1_DH-HQ copy 2/scripts/app.js
@@ -896,11 +896,15 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             <div class="trade-container glass-panel">
               <div class="trade-header">
                 <h3>Trade Preview</h3>
-                <button id="clearTradeButton">Clear</button>
+                <div class="trade-actions">
+                  <button id="toggleTradeButton" aria-label="Hide trade preview">▼</button>
+                  <button id="clearTradeButton">Clear</button>
+                </div>
               </div>
               <div class="trade-body"></div>
               <div class="trade-footnote">• Non-Adjusted Values •</div>
             </div>
+            <button id="showTradeButton" class="hidden" aria-label="Show trade preview">▲</button>
             `;
 
             const tradeBody = tradeSimulator.querySelector('.trade-body');
@@ -963,6 +967,22 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             tradeBody.innerHTML = bodyHtml;
 
             document.getElementById('clearTradeButton').addEventListener('click', clearTrade);
+            const toggleBtn = document.getElementById('toggleTradeButton');
+            const showBtn = document.getElementById('showTradeButton');
+            const tradeContainer = tradeSimulator.querySelector('.trade-container');
+
+            toggleBtn.addEventListener('click', () => {
+                tradeContainer.style.display = 'none';
+                showBtn.classList.remove('hidden');
+                mainContent.style.paddingBottom = `${showBtn.offsetHeight + 40}px`;
+            });
+
+            showBtn.addEventListener('click', () => {
+                tradeContainer.style.display = '';
+                showBtn.classList.add('hidden');
+                mainContent.style.paddingBottom = `${tradeSimulator.offsetHeight + 40}px`;
+            });
+
             mainContent.style.paddingBottom = `${tradeSimulator.offsetHeight + 40}px`;
         }
 

--- a/A1_DH-HQ copy 2/styles/styles.css
+++ b/A1_DH-HQ copy 2/styles/styles.css
@@ -770,7 +770,7 @@
         .trade-container {
             display: flex;
             flex-direction: column;
-            gap: 0.5rem;
+            gap: 0.25rem;
         }
 
         .trade-header { 
@@ -785,11 +785,11 @@
             color: #b0bcdb;
             text-shadow: 0 0 5px rgba(0,0,0,0.5);
         }
-        #clearTradeButton { 
-            background: var(--color-bg-light); 
-            color: var(--color-text-secondary); 
-            font-size: 0.8rem; 
-            padding: 4px 10px; 
+        #clearTradeButton {
+            background: var(--color-bg-light);
+            color: var(--color-text-secondary);
+            font-size: 0.8rem;
+            padding: 4px 10px;
             border-radius: 6px;
             border: 1px solid var(--color-panel-border);
             cursor: pointer;
@@ -798,6 +798,40 @@
         #clearTradeButton:hover {
             color: var(--color-text-primary);
             border-color: var(--color-panel-border-glow);
+        }
+        #toggleTradeButton {
+            background: var(--color-bg-light);
+            color: var(--color-text-secondary);
+            font-size: 0.8rem;
+            padding: 4px 6px;
+            border-radius: 6px;
+            border: 1px solid var(--color-panel-border);
+            cursor: pointer;
+            transition: all 0.2s;
+            margin-right: 0.25rem;
+        }
+        #toggleTradeButton:hover {
+            color: var(--color-text-primary);
+            border-color: var(--color-panel-border-glow);
+        }
+        #showTradeButton {
+            background: var(--color-bg-light);
+            color: var(--color-text-secondary);
+            font-size: 0.8rem;
+            padding: 4px 10px;
+            border-radius: 6px;
+            border: 1px solid var(--color-panel-border);
+            cursor: pointer;
+            transition: all 0.2s;
+            margin: 0 auto;
+        }
+        #showTradeButton:hover {
+            color: var(--color-text-primary);
+            border-color: var(--color-panel-border-glow);
+        }
+        .trade-actions {
+            display: flex;
+            align-items: center;
         }
 
         .trade-body { 
@@ -883,7 +917,7 @@
     font-size: 0.75em;
     color: #A0A6D0;
     font-weight: 300;
-    margin-top: 0.2rem;
+    margin-top: 0;
     padding-bottom: 0.1rem;
 }
 /* Only the Trade Preview popup glass */


### PR DESCRIPTION
## Summary
- Reduce space above trade preview footnote
- Add arrow button to collapse/expand trade preview popup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b44b2c4aac832e822c809290b46a1d