### PR TITLE
feat: add collapsible trade preview

### DIFF
--- a/A1_DH-HQ copy 2/scripts/app.js
+++ b/A1_DH-HQ copy 2/scripts/app.js
@@ -108,7 +108,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         });
 
         // --- State ---
-        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {} };
+        let state = { userId: null, leagues: [], players: {}, oneQbData: {}, sflxData: {}, currentLeagueId: null, isSuperflex: false, cache: {}, teamsToCompare: new Set(), isCompareMode: false, currentRosterView: 'positional', activePositions: new Set(), tradeBlock: {}, isTradeCollapsed: false };
         const assignedLeagueColors = new Map();
         let nextColorIndex = 0;
         const assignedRyColors = new Map();
@@ -896,11 +896,15 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             <div class="trade-container glass-panel">
               <div class="trade-header">
                 <h3>Trade Preview</h3>
-                <button id="clearTradeButton">Clear</button>
+                <div class="trade-actions">
+                  <button id="collapseTradeButton">&#9660;</button>
+                  <button id="clearTradeButton">Clear</button>
+                </div>
               </div>
               <div class="trade-body"></div>
               <div class="trade-footnote">• Non-Adjusted Values •</div>
             </div>
+            <button id="showTradeButton">&#9650;</button>
             `;
 
             const tradeBody = tradeSimulator.querySelector('.trade-body');
@@ -962,7 +966,20 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             
             tradeBody.innerHTML = bodyHtml;
 
+            tradeSimulator.classList.toggle('collapsed', state.isTradeCollapsed);
+
             document.getElementById('clearTradeButton').addEventListener('click', clearTrade);
+            document.getElementById('collapseTradeButton').addEventListener('click', () => {
+                tradeSimulator.classList.add('collapsed');
+                state.isTradeCollapsed = true;
+                mainContent.style.paddingBottom = `${tradeSimulator.offsetHeight + 40}px`;
+            });
+            document.getElementById('showTradeButton').addEventListener('click', () => {
+                tradeSimulator.classList.remove('collapsed');
+                state.isTradeCollapsed = false;
+                mainContent.style.paddingBottom = `${tradeSimulator.offsetHeight + 40}px`;
+            });
+
             mainContent.style.paddingBottom = `${tradeSimulator.offsetHeight + 40}px`;
         }
 

--- a/A1_DH-HQ copy 2/styles/styles.css
+++ b/A1_DH-HQ copy 2/styles/styles.css
@@ -770,7 +770,8 @@
         .trade-container {
             display: flex;
             flex-direction: column;
-            gap: 0.5rem;
+            gap: 0.25rem;
+            position: relative;
         }
 
         .trade-header { 
@@ -779,23 +780,28 @@
             align-items: center; 
             padding: 0 0.5rem; 
         }
-        .trade-header h3 { 
-            font-size: 1rem; 
-            font-weight: 500; 
+        .trade-header h3 {
+            font-size: 1rem;
+            font-weight: 500;
             color: #b0bcdb;
             text-shadow: 0 0 5px rgba(0,0,0,0.5);
         }
-        #clearTradeButton { 
-            background: var(--color-bg-light); 
-            color: var(--color-text-secondary); 
-            font-size: 0.8rem; 
-            padding: 4px 10px; 
+        .trade-actions {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+        }
+        #clearTradeButton, #collapseTradeButton, #showTradeButton {
+            background: var(--color-bg-light);
+            color: var(--color-text-secondary);
+            font-size: 0.8rem;
+            padding: 4px 10px;
             border-radius: 6px;
             border: 1px solid var(--color-panel-border);
             cursor: pointer;
             transition: all 0.2s;
         }
-        #clearTradeButton:hover {
+        #clearTradeButton:hover, #collapseTradeButton:hover, #showTradeButton:hover {
             color: var(--color-text-primary);
             border-color: var(--color-panel-border-glow);
         }
@@ -877,14 +883,23 @@
 
         
 /* Trade Preview footnote */
-.trade-container { position: relative; }
 .trade-footnote {
     text-align: center;
     font-size: 0.75em;
     color: #A0A6D0;
     font-weight: 300;
-    margin-top: 0.2rem;
+    margin-top: 0;
     padding-bottom: 0.1rem;
+}
+#showTradeButton {
+    display: none;
+    margin: 0.25rem auto 0;
+}
+#tradeSimulator.collapsed .trade-container {
+    display: none;
+}
+#tradeSimulator.collapsed #showTradeButton {
+    display: block;
 }
 /* Only the Trade Preview popup glass */
 .trade-container.glass-panel {


### PR DESCRIPTION
## Summary
- add arrow control to collapse or expand trade preview
- tighten spacing above trade preview footnote

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b44b2c4aac832e822c809290b46a1d