### PR TITLE
Improve mobile trade preview layout

### DIFF
--- a/C1_DH-HQ/scripts/app.js
+++ b/C1_DH-HQ/scripts/app.js
@@ -27,6 +27,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const tradeSimulator = document.getElementById('tradeSimulator');
         const mainContent = document.getElementById('content');
         const pageType = document.body.dataset.page || 'welcome';
+        const headerTopRow = document.querySelector('.app-header .header-row');
 
         // --- Menu Button ---
         const menuButton = document.getElementById('menu-button');
@@ -352,8 +353,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             rosterView.classList.toggle('is-trade-mode', state.isCompareMode);
             rosterGrid.classList.toggle('is-preview-mode', state.isCompareMode);
             updateCompareButtonState();
-            renderAllTeamData(state.currentTeams); 
+            renderAllTeamData(state.currentTeams);
             renderTradeBlock();
+            updateMobileHeaderForPreview();
         }
 
         function handleClearCompare(keepUserTeam = false) {
@@ -374,6 +376,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             if (state.currentTeams) {
                 renderAllTeamData(state.currentTeams);
             }
+            updateMobileHeaderForPreview();
         }
 
         function updateCompareButtonState() {
@@ -399,6 +402,15 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             
             if (count < 2 && state.isCompareMode) {
                 handleCompareClick(); // Automatically exit compare mode
+            }
+        }
+
+        function updateMobileHeaderForPreview() {
+            if (!headerTopRow) return;
+            if (window.innerWidth <= 640 && state.isCompareMode) {
+                headerTopRow.classList.add('mobile-hidden');
+            } else {
+                headerTopRow.classList.remove('mobile-hidden');
             }
         }
 
@@ -896,10 +908,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             <div class="trade-container glass-panel">
               <div class="trade-header">
                 <h3>Trade Preview</h3>
-                <div class="trade-actions">
-                  <button id="clearTradeButton">Clear</button>
-                  <button id="collapseTradeButton">Hide &#9662;</button>
-                </div>
+                <button id="collapseTradeButton">Hide &#9662;</button>
+                <button id="clearTradeButton">Clear</button>
               </div>
               <div class="trade-body"></div>
               <div class="trade-footnote">• Non-Adjusted Values •</div>

--- a/C1_DH-HQ/styles/styles.css
+++ b/C1_DH-HQ/styles/styles.css
@@ -242,6 +242,11 @@
             display: none;
         }
 
+        @media (max-width: 640px) {
+            .mobile-hidden {
+                display: none;
+            }
+        }
 /* Ensure hidden truly hides views regardless of ID display rules */
 #playerListView.hidden, #rosterView.hidden { display: none !important; }
 
@@ -775,8 +780,8 @@
         }
 
         .trade-header {
-            display: flex;
-            justify-content: space-between;
+            display: grid;
+            grid-template-columns: 1fr auto 1fr;
             align-items: center;
             padding: 0 0.25rem;
         }
@@ -786,10 +791,12 @@
             color: #b0bcdb;
             text-shadow: 0 0 5px rgba(0,0,0,0.5);
         }
-        .trade-actions {
-            display: flex;
-            align-items: center;
-            gap: 0.25rem;
+        #collapseTradeButton {
+            justify-self: center;
+            margin-right: 0;
+        }
+        #clearTradeButton {
+            justify-self: end;
         }
                 
         /* SHOW TRADE CONTAINER BUTTON */
@@ -822,7 +829,7 @@
             background: #1E1F3030;
             color: #8066CF;
             font-size: 0.8rem;
-            margin-right: 3px;
+            margin-right: 0;
             border: 1px solid #9096C055;
             border-radius: 6px;
             padding: 2px 8px;
@@ -841,7 +848,7 @@
             display: grid;
             grid-template-columns: 1fr auto 1fr;
             gap: 0.25rem;
-            align-items: center;
+            align-items: stretch;
         }
 
         .trade-divider {
@@ -849,6 +856,7 @@
             height: 80%;
             background-image: linear-gradient(to bottom, transparent, var(--color-accent-secondary), transparent);
             opacity: 0.7;
+            align-self: center;
         }
 
         .trade-team-column {
@@ -896,7 +904,9 @@
         }
 
         .trade-total {
-            margin-top: 0.25rem;
+            margin-top: auto;
+            margin-left: 40px !important;
+            margin-right: 40px !important;
             text-align: center;
             font-size: 1rem;
             font-weight: 700;
@@ -914,10 +924,6 @@
         }
         .trade-total.even {
             color: var(--color-accent-secondary);
-        }
-            .trade-total {
-            margin-right: 40px !important;
-            margin-left: 40px !important;
         }
     
         


### PR DESCRIPTION
## Summary
- Collapse top header row on mobile when entering trade preview
- Center trade preview hide button and align team totals without resizing the container
- Add responsive styles for consistent trade preview layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f0213edc832eb57e0de7bf516690